### PR TITLE
Prevent calling setState on unmounted WindowScroller component

### DIFF
--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -88,6 +88,8 @@ export default class WindowScroller extends PureComponent {
     registerScrollListener(this, scrollElement)
 
     window.addEventListener('resize', this._onResize, false)
+    
+    this._isMounted = true
   }
 
   componentWillReceiveProps (nextProps) {
@@ -106,6 +108,8 @@ export default class WindowScroller extends PureComponent {
     unregisterScrollListener(this, this.props.scrollElement || window)
 
     window.removeEventListener('resize', this._onResize, false)
+    
+    this._isMounted = false
   }
 
   render () {
@@ -127,6 +131,8 @@ export default class WindowScroller extends PureComponent {
 
   // Referenced by utils/onScroll
   __handleWindowScrollEvent (event) {
+    if (!this._isMounted) return;
+    
     const { onScroll } = this.props
 
     const scrollElement = this.props.scrollElement || window

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -88,7 +88,7 @@ export default class WindowScroller extends PureComponent {
     registerScrollListener(this, scrollElement)
 
     window.addEventListener('resize', this._onResize, false)
-    
+
     this._isMounted = true
   }
 
@@ -108,7 +108,7 @@ export default class WindowScroller extends PureComponent {
     unregisterScrollListener(this, this.props.scrollElement || window)
 
     window.removeEventListener('resize', this._onResize, false)
-    
+
     this._isMounted = false
   }
 
@@ -131,8 +131,8 @@ export default class WindowScroller extends PureComponent {
 
   // Referenced by utils/onScroll
   __handleWindowScrollEvent (event) {
-    if (!this._isMounted) return;
-    
+    if (!this._isMounted) return
+
     const { onScroll } = this.props
 
     const scrollElement = this.props.scrollElement || window


### PR DESCRIPTION
This a bit of an edge case, when rendering several WindowScroller components on the same page inside a virtual list, the scroll listener can sometimes call setState on an unmounted WindowScroller component (that been scrolled out of view in the virtual list), triggering react's warning.

This PR prevents calling setState if the component has been unmounted.

Thanks for contributing to react-virtualized!

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Run tests locally (`npm test`) to ensure that your change did not break linting or functionality.
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
